### PR TITLE
IndexChain: Fix Orphan issue in DGW by using prev hash instead of height

### DIFF
--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/managers/BlockValidatorHelper.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/managers/BlockValidatorHelper.kt
@@ -11,4 +11,8 @@ open class BlockValidatorHelper(protected val storage: IStorage) {
     fun getPrevious(block: Block, stepBack: Int): Block? {
         return storage.getBlock(block.height - stepBack)
     }
+
+    fun getPrevious(block: Block): Block? {
+        return storage.getBlock(block.previousBlockHash)
+    }
 }

--- a/indexchainkit/src/main/kotlin/io/horizontalsystems/indexchainkit/validators/DarkGravityWaveValidator.kt
+++ b/indexchainkit/src/main/kotlin/io/horizontalsystems/indexchainkit/validators/DarkGravityWaveValidator.kt
@@ -34,7 +34,7 @@ class DarkGravityWaveValidator(
             }
 
             if ((currentBlock.nonce == 0L) != isProofOfStake) {
-                prevBlock = blockHelper.getPrevious(currentBlock, 1)
+                prevBlock = blockHelper.getPrevious(currentBlock)
                 checkNotNull(prevBlock) {
                     if (currentBlock.height == 0) {
                         if (maxTargetBits != block.bits) {
@@ -57,7 +57,7 @@ class DarkGravityWaveValidator(
 
             ++blockCount
             if (blockCount < heightInterval) {
-                prevBlock = blockHelper.getPrevious(currentBlock, 1)
+                prevBlock = blockHelper.getPrevious(currentBlock)
             } else {
                 actualTimeSpan = previousBlock.timestamp - currentBlock.timestamp
             }


### PR DESCRIPTION
This should resolve the issue of DGW calculating the difficulty incorrectly because it retrieved an orphaned block by height in the local blockchain.  The fix will retrieve previous blocks by hash.